### PR TITLE
Add option - noTrailingSlash

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,15 @@ using the standard react helmet api.
 ```javascript
 // In your gatsby-config.js
 plugins: [
-  `gatsby-plugin-react-helmet`,
-  {
-    resolve: `gatsby-plugin-react-helmet-canonical-urls`,
-    options: {
-      siteUrl: `https://www.example.com`,
-    },
-  },
-]
+    `gatsby-plugin-react-helmet`,
+    {
+        resolve: `gatsby-plugin-react-helmet-canonical-urls`,
+        options: {
+            siteUrl: `https://www.example.com`,
+            noTrailingSlash: true
+        }
+    }
+];
 ```
 
 With the above configuration, the plugin will add to the head of every HTML page
@@ -43,3 +44,5 @@ a `rel=canonical` e.g.
 ```html
 <link rel="canonical" href="http://www.example.com/about-us/" />
 ```
+
+Use the `noTrailingSlash` option if you use `gatsby-plugin-remove-trailing-slashes` (or other similar set up to remove trailing slashes)

--- a/README.md
+++ b/README.md
@@ -27,15 +27,14 @@ using the standard react helmet api.
 ```javascript
 // In your gatsby-config.js
 plugins: [
-    `gatsby-plugin-react-helmet`,
-    {
-        resolve: `gatsby-plugin-react-helmet-canonical-urls`,
-        options: {
-            siteUrl: `https://www.example.com`,
-            noTrailingSlash: true
-        }
-    }
-];
+  `gatsby-plugin-react-helmet`,
+  {
+    resolve: `gatsby-plugin-react-helmet-canonical-urls`,
+    options: {
+      siteUrl: `https://www.example.com`,
+    },
+  },
+]
 ```
 
 With the above configuration, the plugin will add to the head of every HTML page
@@ -45,4 +44,5 @@ a `rel=canonical` e.g.
 <link rel="canonical" href="http://www.example.com/about-us/" />
 ```
 
-Use the `noTrailingSlash` option if you use `gatsby-plugin-remove-trailing-slashes` (or other similar set up to remove trailing slashes)
+Additional `options`:
+- `noTrailingSlash` (default `false`): it will remove the trailing slash from canonical link. Use this option if you use [`gatsby-plugin-remove-trailing-slashes`](https://www.npmjs.com/package/gatsby-plugin-remove-trailing-slashes)

--- a/src/wrap-page.js
+++ b/src/wrap-page.js
@@ -1,25 +1,35 @@
-const React = require('react');
-const { Helmet } = require('react-helmet');
+const React = require("react");
+const { Helmet } = require("react-helmet");
 
 module.exports = ({ element, props }, pluginOptions) => {
-  if (pluginOptions && pluginOptions.siteUrl) {
-    const myUrl = `${pluginOptions.siteUrl}${props.location.pathname || '/'}${props.location.search}${props.location.hash}`;
+    if (pluginOptions && pluginOptions.siteUrl) {
+        let path = "";
+        if (pluginOptions.noTrailingSlash)
+            path =
+                props.location.pathname !== "/"
+                    ? props.location.pathname || ""
+                    : "";
+        else path = props.location.pathname || "";
 
-    return (
-      <>
-        <Helmet
-          link={[
-            {
-              rel: 'canonical',
-              key: myUrl,
-              href: myUrl,
-            }
-          ]}
-        />
-        {element}
-      </>
-    );
-  }
+        const myUrl = `${pluginOptions.siteUrl}${path}${props.location.search}${
+            props.location.hash
+        }`;
 
-  return element;
+        return (
+            <>
+                <Helmet
+                    link={[
+                        {
+                            rel: "canonical",
+                            key: myUrl,
+                            href: myUrl
+                        }
+                    ]}
+                />
+                {element}
+            </>
+        );
+    }
+
+    return element;
 };

--- a/src/wrap-page.js
+++ b/src/wrap-page.js
@@ -1,35 +1,30 @@
-const React = require("react");
-const { Helmet } = require("react-helmet");
+const React = require('react');
+const { Helmet } = require('react-helmet');
 
 module.exports = ({ element, props }, pluginOptions) => {
-    if (pluginOptions && pluginOptions.siteUrl) {
-        let path = "";
-        if (pluginOptions.noTrailingSlash)
-            path =
-                props.location.pathname !== "/"
-                    ? props.location.pathname || ""
-                    : "";
-        else path = props.location.pathname || "/";
+  if (pluginOptions && pluginOptions.siteUrl) {
+    let pathname = props.location.pathname || '/';
 
-        const myUrl = `${pluginOptions.siteUrl}${path}${props.location.search}${
-            props.location.hash
-        }`;
+    if (pluginOptions.noTrailingSlash && pathname.endsWith('/'))
+      pathname = pathname.substring(0, pathname.length -1);
 
-        return (
-            <>
-                <Helmet
-                    link={[
-                        {
-                            rel: "canonical",
-                            key: myUrl,
-                            href: myUrl
-                        }
-                    ]}
-                />
-                {element}
-            </>
-        );
-    }
+    const myUrl = `${pluginOptions.siteUrl}${pathname}${props.location.search}${props.location.hash}`;
 
-    return element;
+    return (
+      <>
+        <Helmet
+          link={[
+            {
+              rel: 'canonical',
+              key: myUrl,
+              href: myUrl,
+            }
+          ]}
+        />
+        {element}
+      </>
+    );
+  }
+
+  return element;
 };

--- a/src/wrap-page.js
+++ b/src/wrap-page.js
@@ -9,7 +9,7 @@ module.exports = ({ element, props }, pluginOptions) => {
                 props.location.pathname !== "/"
                     ? props.location.pathname || ""
                     : "";
-        else path = props.location.pathname || "";
+        else path = props.location.pathname || "/";
 
         const myUrl = `${pluginOptions.siteUrl}${path}${props.location.search}${
             props.location.hash


### PR DESCRIPTION
I like to no have trailing slashes and as it was currently built, this plugin always kept the trailing slash on the index page. This new options plays nicely with gatsby-plugin-remove-trailing-slashes and leaves no trailing slashes