### PR TITLE
Added support for excluding path from being added a canonical url

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ plugins: [
       siteUrl: `https://www.example.com`,
     },
   },
-]
+];
 ```
 
 With the above configuration, the plugin will add to the head of every HTML page
@@ -45,4 +45,20 @@ a `rel=canonical` e.g.
 ```
 
 Additional `options`:
+
 - `noTrailingSlash` (default `false`): it will remove the trailing slash from canonical link. Use this option if you use [`gatsby-plugin-remove-trailing-slashes`](https://www.npmjs.com/package/gatsby-plugin-remove-trailing-slashes)
+- `exclude` (Array of `string`, default `undefined`): exclude pages from being added a canonical url. Useful when combining with other SEO-related meta tags like _noindex_.
+
+```JS
+plugins: [
+...
+    {
+      resolve: 'gatsby-plugin-react-helmet-canonical-urls',
+      options: {
+        siteUrl: "https://myurl.com",
+        exclude: ["/exclude-this-path", "/and-this-one"],
+      },
+    },
+...
+]
+```

--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ a `rel=canonical` e.g.
 Additional `options`:
 
 - `noTrailingSlash` (default `false`): it will remove the trailing slash from canonical link. Use this option if you use [`gatsby-plugin-remove-trailing-slashes`](https://www.npmjs.com/package/gatsby-plugin-remove-trailing-slashes)
-- `exclude` (Array of `string`, default `undefined`): exclude pages from being added a canonical url. Useful when combining with other SEO-related meta tags like _noindex_.
+- `exclude` (Array of `string`, default `undefined`): exclude pages from being added a canonical url. Useful when combining with other SEO-related meta tags like _noindex_. (Urls should be listed without trailing slash)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ plugins: [
       siteUrl: `https://www.example.com`,
     },
   },
-];
+]
 ```
 
 With the above configuration, the plugin will add to the head of every HTML page

--- a/README.md
+++ b/README.md
@@ -48,17 +48,3 @@ Additional `options`:
 
 - `noTrailingSlash` (default `false`): it will remove the trailing slash from canonical link. Use this option if you use [`gatsby-plugin-remove-trailing-slashes`](https://www.npmjs.com/package/gatsby-plugin-remove-trailing-slashes)
 - `exclude` (Array of `string`, default `undefined`): exclude pages from being added a canonical url. Useful when combining with other SEO-related meta tags like _noindex_.
-
-```JS
-plugins: [
-...
-    {
-      resolve: 'gatsby-plugin-react-helmet-canonical-urls',
-      options: {
-        siteUrl: "https://myurl.com",
-        exclude: ["/exclude-this-path", "/and-this-one"],
-      },
-    },
-...
-]
-```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-react-helmet-canonical-urls",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Add canonical links to HTML pages Gatsby generates using React Helmet.",
   "main": "index.js",
   "scripts": {

--- a/src/wrap-page.js
+++ b/src/wrap-page.js
@@ -2,8 +2,7 @@ const React = require('react');
 const { Helmet } = require('react-helmet');
 
 const isExcluded = (collection, element) =>
-  Array.isArray(collection) &&
-  collection.indexOf(element.replace(/\/+$/, '')) !== -1;
+  Array.isArray(collection) && collection.includes(element.replace(/\/+$/, ''));
 
 module.exports = ({ element, props }, pluginOptions) => {
   if (

--- a/src/wrap-page.js
+++ b/src/wrap-page.js
@@ -1,8 +1,16 @@
 const React = require('react');
 const { Helmet } = require('react-helmet');
 
+const isExcluded = (collection, element) =>
+  Array.isArray(collection) &&
+  collection.indexOf(element.replace(/\/+$/, '')) !== -1;
+
 module.exports = ({ element, props }, pluginOptions) => {
-  if (pluginOptions && pluginOptions.siteUrl) {
+  if (
+    pluginOptions &&
+    pluginOptions.siteUrl &&
+    !isExcluded(pluginOptions.exclude, props.location.pathname)
+  ) {
     let pathname = props.location.pathname || '/';
 
     if (pluginOptions.noTrailingSlash && pathname.endsWith('/'))


### PR DESCRIPTION
My use case is as follow:
I want the majority of my url processed with a canonical url, but some of them are marked as `noindex` and it's not a good practice to add both a `<meta name="robots" content="noindex"/>` and a `<link rel="canonical"/>`
This PR allows us to do something like this:

In gatsby-config.js:
```JS
plugins: [
...
    {
      resolve: 'gatsby-plugin-react-helmet-canonical-urls',
      options: {
        siteUrl: "https://myurl.com",
        exclude: ["/exclude-this-path"],
      },
    },
...
]
```