### PR TITLE
Added stripHash and stripQueryString options

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ a `rel=canonical` e.g.
 
 Additional `options`:
 
-- `noTrailingSlash` (default `false`): it will remove the trailing slash from canonical link. Use this option if you use [`gatsby-plugin-remove-trailing-slashes`](https://www.npmjs.com/package/gatsby-plugin-remove-trailing-slashes)
 - `exclude` (Array of `string` or `RegExp`, default `undefined`): exclude pages from being added a canonical url. Useful when combining with other SEO-related meta tags like _noindex_. (Urls should be listed without trailing slash)
-- `stripHash` (default `false`): remove hash from the canonical link.
-- `stripQueryString` (default `false`): remove query from the canonical link.
+- `noTrailingSlash` (default `false`): it will remove the trailing slash from canonical link. Use this option if you use [`gatsby-plugin-remove-trailing-slashes`](https://www.npmjs.com/package/gatsby-plugin-remove-trailing-slashes)
+- `noHash` (default `false`): remove hash from the canonical link.
+- `noQueryString` (default `false`): remove query from the canonical link.

--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ Additional `options`:
 - `noTrailingSlash` (default `false`): it will remove the trailing slash from canonical link. Use this option if you use [`gatsby-plugin-remove-trailing-slashes`](https://www.npmjs.com/package/gatsby-plugin-remove-trailing-slashes)
 - `exclude` (Array of `string` or `RegExp`, default `undefined`): exclude pages from being added a canonical url. Useful when combining with other SEO-related meta tags like _noindex_. (Urls should be listed without trailing slash)
 - `stripHash` (default `false`): remove hash from the canonical link.
-- `stripQuery` (default `false`): remove query from the canonical link.
+- `stripQueryString` (default `false`): remove query from the canonical link.

--- a/README.md
+++ b/README.md
@@ -48,3 +48,5 @@ Additional `options`:
 
 - `noTrailingSlash` (default `false`): it will remove the trailing slash from canonical link. Use this option if you use [`gatsby-plugin-remove-trailing-slashes`](https://www.npmjs.com/package/gatsby-plugin-remove-trailing-slashes)
 - `exclude` (Array of `string` or `RegExp`, default `undefined`): exclude pages from being added a canonical url. Useful when combining with other SEO-related meta tags like _noindex_. (Urls should be listed without trailing slash)
+- `stripHash` (default `false`): remove hash from the canonical link.
+- `stripQuery` (default `false`): remove query from the canonical link.

--- a/src/wrap-page.js
+++ b/src/wrap-page.js
@@ -1,6 +1,12 @@
 const React = require('react');
 const { Helmet } = require('react-helmet');
 
+const defaultPluginOptions = {
+  noTrailingSlash: false,
+  stripQueryString: false,
+  stripHash: false,
+};
+
 const isExcluded = (excludes, element) => {
   if (!Array.isArray(excludes))
     return false;
@@ -14,20 +20,25 @@ const isExcluded = (excludes, element) => {
   });
 }
 
-module.exports = ({ element, props }, pluginOptions) => {
-  if (
-    pluginOptions &&
-    pluginOptions.siteUrl &&
-    !isExcluded(pluginOptions.exclude, props.location.pathname)
-  ) {
-    let pathname = props.location.pathname || '/';
+module.exports = ({ element, props: { location } }, pluginOptions = {}) => {
+  const options = Object.assign(defaultPluginOptions, pluginOptions);
 
-    if (pluginOptions.noTrailingSlash && pathname.endsWith('/'))
+  if (
+    options.siteUrl &&
+    !isExcluded(options.exclude, location.pathname)
+  ) {
+    let pathname = location.pathname || '/';
+
+    if (options.noTrailingSlash && pathname.endsWith('/'))
       pathname = pathname.substring(0, pathname.length - 1);
 
-    const myUrl = `${pluginOptions.siteUrl}${pathname}${props.location.search}${
-      props.location.hash
-    }`;
+    let myUrl = `${options.siteUrl}${pathname}`;
+
+    if(!options.stripQueryString)
+      myUrl += location.search;
+
+    if(!options.stripHash)
+      myUrl += location.hash;
 
     return (
       <>

--- a/src/wrap-page.js
+++ b/src/wrap-page.js
@@ -3,8 +3,8 @@ const { Helmet } = require('react-helmet');
 
 const defaultPluginOptions = {
   noTrailingSlash: false,
-  stripQueryString: false,
-  stripHash: false,
+  nopQueryString: false,
+  nopHash: false,
 };
 
 const isExcluded = (excludes, element) => {
@@ -21,7 +21,7 @@ const isExcluded = (excludes, element) => {
 }
 
 module.exports = ({ element, props: { location } }, pluginOptions = {}) => {
-  const options = Object.assign(defaultPluginOptions, pluginOptions);
+  const options = Object.assign({}, defaultPluginOptions, pluginOptions);
 
   if (
     options.siteUrl &&
@@ -34,10 +34,10 @@ module.exports = ({ element, props: { location } }, pluginOptions = {}) => {
 
     let myUrl = `${options.siteUrl}${pathname}`;
 
-    if(!options.stripQueryString)
+    if(!options.noQueryString)
       myUrl += location.search;
 
-    if(!options.stripHash)
+    if(!options.noHash)
       myUrl += location.hash;
 
     return (

--- a/src/wrap-page.test.js
+++ b/src/wrap-page.test.js
@@ -1,22 +1,22 @@
-const React = require('react');
-const ReactDOMServer = require('react-dom/server');
-const { Helmet } = require('react-helmet');
-const wrap = require('./wrap-page');
+const React = require("react");
+const ReactDOMServer = require("react-dom/server");
+const { Helmet } = require("react-helmet");
+const wrap = require("./wrap-page");
 
-it('should set canonical', () => {
+it("should set canonical", () => {
   const element = wrap(
     {
-      element: 'element',
+      element: "element",
       props: {
         location: {
-          pathname: '/pathname/',
-          search: '?search',
-          hash: '#hash',
-        },
-      },
+          pathname: "/pathname/",
+          search: "?search",
+          hash: "#hash"
+        }
+      }
     },
     {
-      siteUrl: 'http://my-site.com',
+      siteUrl: "http://my-site.com"
     }
   );
 
@@ -24,23 +24,23 @@ it('should set canonical', () => {
 
   const link = Helmet.renderStatic().link.toComponent();
   expect(link.length).toBe(1);
-  expect(link[0].props.href).toBe('http://my-site.com/pathname/?search#hash');
+  expect(link[0].props.href).toBe("http://my-site.com/pathname/?search#hash");
 });
 
-it('should use a slash as pathname, if it is falsy', () => {
+it("should use a slash as pathname, if it is falsy", () => {
   const element = wrap(
     {
-      element: 'element',
+      element: "element",
       props: {
         location: {
-          pathname: '',
-          search: '?search',
-          hash: '#hash',
-        },
-      },
+          pathname: "",
+          search: "?search",
+          hash: "#hash"
+        }
+      }
     },
     {
-      siteUrl: 'http://my-site.com',
+      siteUrl: "http://my-site.com"
     }
   );
 
@@ -48,26 +48,26 @@ it('should use a slash as pathname, if it is falsy', () => {
 
   const link = Helmet.renderStatic().link.toComponent();
   expect(link.length).toBe(1);
-  expect(link[0].props.href).toBe('http://my-site.com/?search#hash');
+  expect(link[0].props.href).toBe("http://my-site.com/?search#hash");
 });
 
-it('should element set canonial, it should use it', () => {
-  const canonical = 'https://this-is-a.canonical.test/more-test';
+it("should element set canonial, it should use it", () => {
+  const canonical = "https://this-is-a.canonical.test/more-test";
   const element = wrap(
     {
       element: React.createElement(Helmet, {
-        link: [{ rel: 'canonical', key: canonical, href: canonical }],
+        link: [{ rel: "canonical", key: canonical, href: canonical }]
       }),
       props: {
         location: {
-          pathname: '/example/',
-          search: '?search',
-          hash: '#hash',
-        },
-      },
+          pathname: "/example/",
+          search: "?search",
+          hash: "#hash"
+        }
+      }
     },
     {
-      siteUrl: 'http://my-site.com',
+      siteUrl: "http://my-site.com"
     }
   );
 
@@ -75,24 +75,24 @@ it('should element set canonial, it should use it', () => {
 
   const link = Helmet.renderStatic().link.toComponent();
   expect(link.length).toBe(1);
-  expect(link[0].props.href).toBe('https://this-is-a.canonical.test/more-test');
+  expect(link[0].props.href).toBe("https://this-is-a.canonical.test/more-test");
 });
 
-it('should remove trailing slash, if `noTrailingSlash` option is used', () => {
+it("should remove trailing slash, if `noTrailingSlash` option is used", () => {
   const element = wrap(
     {
-      element: 'element',
+      element: "element",
       props: {
         location: {
-          pathname: '/pathname/',
-          search: '?search',
-          hash: '#hash',
-        },
-      },
+          pathname: "/pathname/",
+          search: "?search",
+          hash: "#hash"
+        }
+      }
     },
     {
-      siteUrl: 'http://my-site.com',
-      noTrailingSlash: true,
+      siteUrl: "http://my-site.com",
+      noTrailingSlash: true
     }
   );
 
@@ -100,15 +100,65 @@ it('should remove trailing slash, if `noTrailingSlash` option is used', () => {
 
   const link = Helmet.renderStatic().link.toComponent();
   expect(link.length).toBe(1);
-  expect(link[0].props.href).toBe('http://my-site.com/pathname?search#hash');
+  expect(link[0].props.href).toBe("http://my-site.com/pathname?search#hash");
 });
 
-it('should not set canonical if no options is passed', () => {
-  const element = wrap({
-    element: 'element',
-    props: {
-      location: {},
+it("should remove query string, if `noQueryString` option is used", () => {
+  const element = wrap(
+    {
+      element: "element",
+      props: {
+        location: {
+          pathname: "/pathname/",
+          search: "?search",
+          hash: "#hash"
+        }
+      }
     },
+    {
+      siteUrl: "http://my-site.com",
+      noQueryString: true
+    }
+  );
+
+  ReactDOMServer.renderToString(element);
+
+  const link = Helmet.renderStatic().link.toComponent();
+  expect(link.length).toBe(1);
+  expect(link[0].props.href).toBe("http://my-site.com/pathname/#hash");
+});
+
+it("should remove hash, if `noHash` option is used", () => {
+  const element = wrap(
+    {
+      element: "element",
+      props: {
+        location: {
+          pathname: "/pathname/",
+          search: "?search",
+          hash: "#hash"
+        }
+      }
+    },
+    {
+      siteUrl: "http://my-site.com",
+      noHash: true
+    }
+  );
+
+  ReactDOMServer.renderToString(element);
+
+  const link = Helmet.renderStatic().link.toComponent();
+  expect(link.length).toBe(1);
+  expect(link[0].props.href).toBe("http://my-site.com/pathname/?search");
+});
+
+it("should not set canonical if no options is passed", () => {
+  const element = wrap({
+    element: "element",
+    props: {
+      location: {}
+    }
   });
 
   ReactDOMServer.renderToString(element);
@@ -117,13 +167,13 @@ it('should not set canonical if no options is passed', () => {
   expect(link.length).toBe(0);
 });
 
-it('should not set canonical if no siteUrl option is passed', () => {
+it("should not set canonical if no siteUrl option is passed", () => {
   const element = wrap(
     {
-      element: 'element',
+      element: "element",
       props: {
-        location: {},
-      },
+        location: {}
+      }
     },
     {}
   );
@@ -135,25 +185,25 @@ it('should not set canonical if no siteUrl option is passed', () => {
 });
 
 test.each([
-  [['/my-pathname']],
-  [['/something', '/my-pathname']],
+  [["/my-pathname"]],
+  [["/something", "/my-pathname"]],
   [[/pathname/]],
   [[/^not/, /pathname/]],
-  [[new RegExp('pathname')]],
-])('should not set canonical if pathname is excluded: %p', exclude => {
+  [[new RegExp("pathname")]]
+])("should not set canonical if pathname is excluded: %p", exclude => {
   const element = wrap(
     {
-      element: 'element',
+      element: "element",
       props: {
         location: {
-          pathname: '/my-pathname/',
-          search: '',
-          hash: '',
-        },
-      },
+          pathname: "/my-pathname/",
+          search: "",
+          hash: ""
+        }
+      }
     },
     {
-      siteUrl: 'http://my-site.com',
+      siteUrl: "http://my-site.com",
       exclude
     }
   );


### PR DESCRIPTION
Added `stripHash` and `stripQueryString` options.

I tried adding tests but was having some issues with it. Tests all passed when I started, then after I made the changes to `wrap-page.js` the `should not set canonical if no options are passed` and `should not set canonical if no siteUrl option is passed` tests failed. I logged the options being passed to each test and some options seemed to persist between tests. Commenting out all of the other tests except those two made them pass, so I think all the test need to be rewritten somehow.