### PR TITLE
Fix: address typo in defaultPluginOptions

### DIFF
--- a/src/wrap-page.js
+++ b/src/wrap-page.js
@@ -3,8 +3,8 @@ const { Helmet } = require('react-helmet');
 
 const defaultPluginOptions = {
   noTrailingSlash: false,
-  nopQueryString: false,
-  nopHash: false,
+  noQueryString: false,
+  noHash: false,
 };
 
 const isExcluded = (excludes, element) => {


### PR DESCRIPTION
`nopQueryString` and `nopHash` have an extra p in them. 