### PR TITLE
Used minimatch to match paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-helmet": "*"
   },
   "dependencies": {
-    "@babel/runtime": "^7.3.1"
+    "@babel/runtime": "^7.3.1",
+    "minimatch": "^3.0.4"
   }
 }

--- a/src/wrap-page.js
+++ b/src/wrap-page.js
@@ -1,5 +1,6 @@
 const React = require('react');
 const { Helmet } = require('react-helmet');
+const minimatch = require("minimatch");
 
 const defaultPluginOptions = {
   noTrailingSlash: false,
@@ -14,9 +15,12 @@ const isExcluded = (excludes, element) => {
 
   return excludes.some(exclude => {
     if (exclude instanceof RegExp) return element.match(exclude);
-    return exclude.includes(element);
+    return minimatch(withoutTrailingSlash(element), withoutTrailingSlash(exclude));
   });
 };
+
+const withoutTrailingSlash = path =>
+  path === `/` ? path : path.replace(/\/$/, ``)
 
 module.exports = ({ element, props: { location } }, pluginOptions = {}) => {
   const options = Object.assign({}, defaultPluginOptions, pluginOptions);


### PR DESCRIPTION
Hi,

just a workaround for RegExp not working, I made this pull request inspired by [gatsby-plugin-sitemap](https://github.com/gatsbyjs/gatsby/blob/2f0044d5dcc43b4570cac8945f61edf3dec0f5bc/packages/gatsby-plugin-sitemap/src/internals.js#L11) which uses `minimap`.

If you think it could be a good idea to use `minimap`, I'm glad I could help.