### PR TITLE
feat(plugin): add include option and convert matching to regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,48 @@ a `rel=canonical` e.g.
 <link rel="canonical" href="http://www.example.com/about-us/" />
 ```
 
-Additional `options`:
+#### `options`
 
-- `exclude` (Array of `string` or `RegExp`, default `undefined`): exclude pages from being added a canonical url. Useful when combining with other SEO-related meta tags like _noindex_. (Urls should be listed without trailing slash)
-- `noTrailingSlash` (default `false`): it will remove the trailing slash from canonical link. Use this option if you use [`gatsby-plugin-remove-trailing-slashes`](https://www.npmjs.com/package/gatsby-plugin-remove-trailing-slashes)
-- `noHash` (default `false`): remove hash from the canonical link.
-- `noQueryString` (default `false`): remove query from the canonical link.
+##### `siteUrl`
+- **Type:** `string`
+- **Required**
+- The root address of your site (e.g., `https://www.example.com`). This is required to generate the full canonical URL. The plugin will do nothing if this is not provided.
+
+##### `include`
+- **Type:** `(string | RegExp)[]`
+- **Default:** `undefined`
+- If provided, the plugin operates in **whitelist mode**. A canonical URL will be generated **only** for paths that match a pattern in this array. If this option is used, `exclude` is ignored. Note that strings are treated as regular expression patterns.
+  - **Example:** `include: ['/products/']` will match `/products/cool-item` but not `/about-us`.
+
+##### `exclude`
+- **Type:** `(string | RegExp)[]`
+- **Default:** `undefined`
+- If `include` is not used, the plugin operates in **blacklist mode**. This option allows you to exclude specific paths from receiving a canonical URL. This is useful for pages with other SEO tags like `noindex`.
+
+> #### ⚠️ Breaking Change in v2.0.0
+> String patterns in the `exclude` and `include` arrays are now treated as **Regular Expressions** instead of exact string matches. This provides more powerful and predictable matching.
+>
+> **Old Behavior (v1.x.x):**
+> `exclude: ['/admin']` would only block the exact path `/admin`. It would **not** block `/admin/login`.
+>
+> **New Behavior (v2.x.x):**
+> `exclude: ['/admin']` now functions like a regex and will block any path that **contains** the string `/admin`, including `/admin` itself, `/admin/login`, and `/some/other/admin/page`.
+>
+> **✅ How to Restore Old Behavior:**
+> To match an exact path only, use start (`^`) and end (`$`) anchors in your string:
+> `exclude: ['^/admin$']`
+
+##### `noTrailingSlash`
+- **Type:** `boolean`
+- **Default:** `false`
+- If `true`, removes the trailing slash from the generated canonical URL. This should be used if your site enforces a no-trailing-slash policy, for example, by using `gatsby-plugin-remove-trailing-slashes`.
+
+##### `noQueryString`
+- **Type:** `boolean`
+- **Default:** `false`
+- If `true`, removes query parameters (e.g., `?id=123`) from the generated canonical URL.
+
+##### `noHash`
+- **Type:** `boolean`
+- **Default:** `false`
+- If `true`, removes the hash fragment (e.g., `#section-one`) from the generated canonical URL.

--- a/src/wrap-page.js
+++ b/src/wrap-page.js
@@ -86,11 +86,11 @@ module.exports = (
     let canonicalUrl = `${siteUrl}${pathname}`;
 
     if (!options.noQueryString) {
-      canonicalUrl += location.search;
+      canonicalUrl += (location.search || '');
     }
 
     if (!options.noHash) {
-      canonicalUrl += location.hash;
+      canonicalUrl += (location.hash || '');
     }
 
     return (

--- a/src/wrap-page.js
+++ b/src/wrap-page.js
@@ -7,45 +7,105 @@ const defaultPluginOptions = {
   noHash: false,
 };
 
-const isExcluded = (excludes, element) => {
-  if (!Array.isArray(excludes)) return false;
+/**
+ * Checks if a given pathname matches any of the provided patterns.
+ *
+ * @param {(string|RegExp)[]} patterns - An array of strings or regular expressions to match against.
+ * @param {string} pathname - The URL pathname to test.
+ * @returns {boolean} - True if a match is found, otherwise false.
+ */
+const isMatch = (patterns, pathname) => {
+  if (!Array.isArray(patterns) || patterns.length === 0) {
+    return false;
+  }
 
-  element = element.replace(/\/+$/, '');
+  // Normalize the pathname to ensure it starts with a / and has no trailing slash.
+  const processedPathname = `/${(pathname || '').replace(/^\/|\/$/g, '')}`;
 
-  return excludes.some(exclude => {
-    if (exclude instanceof RegExp) return element.match(exclude);
-    return exclude.includes(element);
+  return patterns.some(pattern => {
+    if (pattern instanceof RegExp) {
+      return pattern.test(processedPathname);
+    }
+
+    if (typeof pattern === 'string') {
+      try {
+        // Attempt to convert string patterns to RegExp.
+        const regex = new RegExp(pattern);
+        return regex.test(processedPathname);
+      } catch (e) {
+        console.error(
+          `[gatsby-plugin-react-helmet-canonical-urls] Invalid regex pattern provided: "${pattern}"`
+        );
+        return false;
+      }
+    }
+    // Ignore patterns that are not strings or RegExp.
+    return false;
   });
 };
 
-module.exports = ({ element, props: { location } }, pluginOptions = {}) => {
+/**
+ * Gatsby SSR API to wrap the page element.
+ */
+module.exports = (
+  { element, props: { location } },
+  pluginOptions = {}
+) => {
   const options = Object.assign({}, defaultPluginOptions, pluginOptions);
+  const { siteUrl, include, exclude } = options;
 
-  if (options.siteUrl && !isExcluded(options.exclude, location.pathname)) {
+  if (!siteUrl) {
+    console.warn(
+      '[gatsby-plugin-react-helmet-canonical-urls] `siteUrl` is not configured in your gatsby-config.js. Canonical URLs will not be generated.'
+    );
+    return element;
+  }
+
+  // Determine the logic mode: "include" (whitelist) or "exclude" (blacklist).
+  const hasIncludes = Array.isArray(include) && include.length > 0;
+  const patterns = hasIncludes ? include : exclude;
+  const pathIsMatched = isMatch(patterns, location.pathname);
+
+  // In include mode, generate if the path matches.
+  // In exclude mode, generate if the path does NOT match.
+  const shouldGenerateCanonical = hasIncludes ? pathIsMatched : !pathIsMatched;
+
+  if (shouldGenerateCanonical) {
     let pathname = location.pathname || '/';
 
-    if (options.noTrailingSlash && pathname.endsWith('/'))
-      pathname = pathname.substring(0, pathname.length - 1);
+    // Remove trailing slash if configured.
+    if (
+      options.noTrailingSlash &&
+      pathname.length > 1 &&
+      pathname.endsWith('/')
+    ) {
+      pathname = pathname.slice(0, -1);
+    }
 
-    let myUrl = `${options.siteUrl}${pathname}`;
+    // Construct the full canonical URL.
+    let canonicalUrl = `${siteUrl}${pathname}`;
 
-    if (!options.noQueryString) myUrl += location.search;
+    if (!options.noQueryString) {
+      canonicalUrl += location.search;
+    }
 
-    if (!options.noHash) myUrl += location.hash;
+    if (!options.noHash) {
+      canonicalUrl += location.hash;
+    }
 
     return (
-      <>
+      <React.Fragment>
         <Helmet
           link={[
             {
               rel: 'canonical',
-              key: myUrl,
-              href: myUrl,
+              key: canonicalUrl,
+              href: canonicalUrl,
             },
           ]}
         />
         {element}
-      </>
+      </React.Fragment>
     );
   }
 


### PR DESCRIPTION
Enhances path filtering by introducing an `include` option and converting all pattern matching to use regular expressions.

**Changes:**
- Add new `include` option for whitelist-based filtering.
- Refactor `exclude` and `include` pattern matching to treat strings as regular expressions.
- Expand test suite with coverage for include/exclude logic and new regex behaviour.
- Update README

**BREAKING CHANGE:**
Pattern matching for `include` and `exclude` now uses regular expressions instead of simple string matching. To match an exact path (the previous behaviour), users must update their configuration to use start (`^`) and end (`$`) anchors.

**Example:**
```diff
- exclude: ['/admin']
+ exclude: ['^/admin$']
```

Closes #14 
Closes #34 